### PR TITLE
Issue with leading slashes

### DIFF
--- a/CriPakTools/Program.cs
+++ b/CriPakTools/Program.cs
@@ -69,7 +69,7 @@ namespace CriPakTools
                         chunk = cpk.DecompressCRILAYLA(chunk, size);
                     }
 
-                    File.WriteAllBytes(((entries[i].DirName != null) ? entries[i].DirName + "/" : "") + entries[i].FileName.ToString(), chunk);
+                    File.WriteAllBytes((((entries[i].DirName != null) ? entries[i].DirName + "/" : "") + entries[i].FileName.ToString()).TrimStart('/'), chunk);
                 }
             }
             else


### PR DESCRIPTION
Some cpk files contain entries with a leading slash causing the program to crash. This is because it tries to write to the root of the current drive, which is usually write-protected. The proposed change instead strips the leading slash and extracts it to the current directory.